### PR TITLE
fix interpreter for uninstall script

### DIFF
--- a/uninstall
+++ b/uninstall
@@ -1,4 +1,4 @@
-#!/System/Library/Frameworks/Ruby.framework/Versions/Current/usr/bin/ruby
+#!/usr/bin/env ruby
 
 require "fileutils"
 require "optparse"


### PR DESCRIPTION
the original interprepter is apparently for OSX instead of linux.

I'm maintaining a debian package called linuxbrew-wrapper, and
the patch comes from that package. I'm now
doing the package content transition as the linuxbrew upstream transition.

Actually Debian/Ubuntu users can use that package.
Well please inform me when doing large changes. Thanks :-)
