### PR TITLE
install script: change shell profile defaults

### DIFF
--- a/install
+++ b/install
@@ -194,8 +194,8 @@ end
 # return the shell profile file based on users' preference shell
 def shell_profile
   case ENV["SHELL"]
-  when %r{/bash} && File.writable?("~/.bash_profile") then "~/.bash_profile"
-  when %r{/zsh} then "~/.zprofile"
+  when %r{/bash$} && File.readable?("~/.bash_profile") then "~/.bash_profile"
+  when %r{/zsh$} then "~/.zprofile"
   else "~/.profile"
   end
 end

--- a/install
+++ b/install
@@ -194,10 +194,9 @@ end
 # return the shell profile file based on users' preference shell
 def shell_profile
   case ENV["SHELL"]
-  when %r{/(ba)?sh} then "~/.bash_profile"
-  when %r{/zsh} then "~/.zshrc"
-  when %r{/ksh} then "~/.kshrc"
-  else "~/.bash_profile"
+  when %r{/bash} && File.writable?("~/.bash_profile") then "~/.bash_profile"
+  when %r{/zsh} then "~/.zprofile"
+  else "~/.profile"
   end
 end
 


### PR DESCRIPTION
- Use `~/.bash_profile` for Bash. This is only done if the file exists and is writable
  (otherwise it would take precedence over a possibly existing `~/.profile` script)
- Use `~./profile` as the fallback, as that's shell-agnostic
- Use `~/.zprofile` instead of `~/.zshrc`, per https://superuser.com/a/187673/112593
- Let ksh fall back to `~./profile`, per
  http://osr507doc.sco.com/en/OSUserG/_The_Korn_shell_profile_and_kshrc.html

These changes make the install script consistent with the Linuxbrew/brew README,
namely the instructions in the "[Install Linuxbrew](https://github.com/Linuxbrew/brew/blob/master/README.md#install-linuxbrew)" section.

See Linuxbrew/brew#235 for context.