### PR TITLE
Add Homebrew to mkdirs

### DIFF
--- a/install
+++ b/install
@@ -267,7 +267,7 @@ user_chmods = zsh_dirs.select { |d| user_only_chmod?(d) }
 chmods = group_chmods + user_chmods
 chowns = chmods.select { |d| chown?(d) }
 chgrps = chmods.select { |d| chgrp?(d) }
-mkdirs = %w[Cellar bin etc include lib opt sbin share share/zsh share/zsh/site-functions var].
+mkdirs = %w[Cellar Homebrew bin etc include lib opt sbin share share/zsh share/zsh/site-functions var].
          map { |d| File.join(HOMEBREW_PREFIX, d) }.
          reject { |d| File.directory?(d) }
 mkdirs << HOMEBREW_REPOSITORY unless mkdirs.include?(HOMEBREW_REPOSITORY) || File.directory?(HOMEBREW_REPOSITORY)


### PR DESCRIPTION
Fix the error:
```
==> Downloading and installing Linuxbrew...
/home/linuxbrew/.linuxbrew/Homebrew/.git: Permission denied
```