### PR TITLE
Set umask to 022 before running installation.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
 set -eu
+umask 022
 which ruby >/dev/null || eval "`curl -fsSL https://raw.githubusercontent.com/Linuxbrew/install/master/install-ruby`"
 exec ruby -e "`curl -fsSL https://raw.githubusercontent.com/Linuxbrew/install/master/install`"


### PR DESCRIPTION
This ensures that the /home/linuxbrew directory will be readable by
the user.

This addresses #33.  For most users, this will have no effect, since they already use this umask.