### PR TITLE
fixed sudo checks

### DIFF
--- a/install
+++ b/install
@@ -94,8 +94,10 @@ end
 def sudo?
   return @have_sudo unless @have_sudo.nil?
 
-  Kernel.system "/usr/bin/sudo", "-v"
-  @have_sudo = $CHILD_STATUS && $CHILD_STATUS.success?
+  Kernel.system "/usr/bin/sudo", "-l", "mkdir"
+  @have_sudo = $CHILD_STATUS.success?
+rescue Interrupt
+  exit
 end
 
 def sudo(*args)
@@ -237,8 +239,8 @@ unless mac?
   if File.writable?(HOMEBREW_PREFIX_DEFAULT) || File.writable?("/home/linuxbrew") || File.writable?("/home")
     HOMEBREW_PREFIX = HOMEBREW_PREFIX_DEFAULT.freeze
   else
-    Kernel.system "/usr/bin/sudo -n -v 2>/dev/null"
-    unless $CHILD_STATUS.success?
+    sudo_output = `/usr/bin/sudo -n -l mkdir 2>&1`
+    if !$CHILD_STATUS.success? && sudo_output == "sudo: a password is required\n"
       ohai "Select the Linuxbrew installation directory"
       puts "- #{Tty.bold}Enter your password#{Tty.reset} to install to #{Tty.underline}#{HOMEBREW_PREFIX_DEFAULT}#{Tty.reset} (#{Tty.bold}recommended#{Tty.reset})"
       puts "- #{Tty.bold}Press Control-D#{Tty.reset} to install to #{Tty.underline}#{ENV["HOME"]}/.linuxbrew#{Tty.reset}"

--- a/install-ruby
+++ b/install-ruby
@@ -9,9 +9,8 @@ case $(uname -m) in
   *) echo "Error: Your CPU $(uname -m) is not supported." >&2; exit 1 ;;
 esac
 
-if test -w /home/linuxbrew || sudo -v; then
+if test -w /home/linuxbrew || /usr/bin/sudo -p "[sudo] Enter password for $USER to install Ruby: " mkdir -p /home/linuxbrew; then
 	prefix=/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor
-	test -d /home/linuxbrew || sudo mkdir -p /home/linuxbrew
 	test -w /home/linuxbrew || sudo chown $USER: /home/linuxbrew
 else
 	prefix=~/.linuxbrew/Homebrew/Library/Homebrew/vendor


### PR DESCRIPTION
To check `sudo` command,
it is better to check `/bin/mkdir -p #{HOMEBREW_PREFIX_DEFAULT}"` command instead of using `-v`,
because users can have limited sudo right and they can `sudo -v` test.

In addition **Select the Linuxbrew installation directory** prompts were not working before.
This PR changes to do:

* Check `/usr/bin/sudo -n /bin/mkdir -p #{HOMEBREW_PREFIX_DEFAULT}`
* If not, ask user to select (Enter password for /home/linuxbrew, C-D for $HOME/, C-C to interrupt)
* If Password is entered, try `/usr/bin/sudo /bin/mkdir -p #{HOMEBREW_PREFIX_DEFAULT}`
* If not, or C-D, use $HOME/