### PR TITLE
Handle missing USER env var

### DIFF
--- a/install
+++ b/install
@@ -363,7 +363,7 @@ if File.directory? HOMEBREW_PREFIX
   sudo "/bin/chmod", "u+rwx", *chmods unless chmods.empty?
   sudo "/bin/chmod", "g+rwx", *group_chmods unless group_chmods.empty?
   sudo "/bin/chmod", "755", *user_chmods unless user_chmods.empty?
-  sudo "/bin/chown", user, *chowns unless chowns.empty?
+  sudo "/bin/chown", ENV["USER"], *chowns unless chowns.empty?
   sudo "/bin/chgrp", group, *chgrps unless chgrps.empty?
 else
   sudo "/bin/mkdir", "-p", HOMEBREW_PREFIX
@@ -374,14 +374,14 @@ unless mkdirs.empty?
   sudo "/bin/mkdir", "-p", *mkdirs
   sudo "/bin/chmod", "g+rwx", *mkdirs
   sudo "/bin/chmod", "755", *zsh_dirs
-  sudo "/bin/chown", user, *mkdirs
+  sudo "/bin/chown", ENV["USER"], *mkdirs
   sudo "/bin/chgrp", group, *mkdirs
 end
 
 [HOMEBREW_CACHE, HOMEBREW_OLD_CACHE].compact.each do |cache|
   sudo "/bin/mkdir", "-p", cache unless File.directory? cache
   sudo "/bin/chmod", "g+rwx", cache if chmod? cache
-  sudo "/bin/chown", user, cache if chown? cache
+  sudo "/bin/chown", ENV["USER"], cache if chown? cache
   sudo "/bin/chgrp", group, cache if chgrp? cache
 end
 

--- a/install
+++ b/install
@@ -220,9 +220,10 @@ def shell_profile
   end
 end
 
-def user
-  @user ||= ENV["USER"] || `id -un`.chomp
-end
+# The USER env var is not guaranteed to be available, so fall back to id if not
+# provided. We destructively set it in the environment to make it available to
+# any sub-processes called.
+ENV["USER"] = `id -un`.chomp unless ENV["USER"]
 
 # Invalidate sudo timestamp before exiting (if it wasn't active before).
 Kernel.system "/usr/bin/sudo -n -v 2>/dev/null"
@@ -235,8 +236,8 @@ Dir.chdir "/usr"
 ####################################################################### script
 abort "Mac OS X too old, see: https://github.com/mistydemeo/tigerbrew" if mac? && macos_version < "10.5"
 abort "Don't run this as root!" if Process.uid.zero?
-abort <<-EOABORT unless !mac? || `dsmemberutil checkmembership -U "#{user}" -G admin`.include?("user is a member")
-This script requires the user #{user} to be an Administrator.
+abort <<-EOABORT unless !mac? || `dsmemberutil checkmembership -U "#{ENV["USER"]}" -G admin`.include?("user is a member")
+This script requires the user #{ENV["USER"]} to be an Administrator.
 EOABORT
 
 unless mac?
@@ -341,7 +342,7 @@ unless user_chmods.empty?
   puts(*user_chmods)
 end
 unless chowns.empty?
-  ohai "The following existing directories will have their owner set to #{Tty.underline}#{user}#{Tty.reset}:"
+  ohai "The following existing directories will have their owner set to #{Tty.underline}#{ENV["USER"]}#{Tty.reset}:"
   puts(*chowns)
 end
 unless chgrps.empty?
@@ -366,7 +367,7 @@ if File.directory? HOMEBREW_PREFIX
   sudo "/bin/chgrp", group, *chgrps unless chgrps.empty?
 else
   sudo "/bin/mkdir", "-p", HOMEBREW_PREFIX
-  sudo "/bin/chown", "#{user}:#{group}", HOMEBREW_PREFIX
+  sudo "/bin/chown", "#{ENV["USER"]}:#{group}", HOMEBREW_PREFIX
 end
 
 unless mkdirs.empty?

--- a/install
+++ b/install
@@ -220,6 +220,10 @@ def shell_profile
   end
 end
 
+def user
+  @user ||= ENV["USER"] || `id -un`.chomp
+end
+
 # Invalidate sudo timestamp before exiting (if it wasn't active before).
 Kernel.system "/usr/bin/sudo -n -v 2>/dev/null"
 at_exit { Kernel.system "/usr/bin/sudo", "-k" } unless $CHILD_STATUS.success?
@@ -231,8 +235,8 @@ Dir.chdir "/usr"
 ####################################################################### script
 abort "Mac OS X too old, see: https://github.com/mistydemeo/tigerbrew" if mac? && macos_version < "10.5"
 abort "Don't run this as root!" if Process.uid.zero?
-abort <<-EOABORT unless !mac? || `dsmemberutil checkmembership -U "#{ENV["USER"]}" -G admin`.include?("user is a member")
-This script requires the user #{ENV["USER"]} to be an Administrator.
+abort <<-EOABORT unless !mac? || `dsmemberutil checkmembership -U "#{user}" -G admin`.include?("user is a member")
+This script requires the user #{user} to be an Administrator.
 EOABORT
 
 unless mac?
@@ -337,7 +341,7 @@ unless user_chmods.empty?
   puts(*user_chmods)
 end
 unless chowns.empty?
-  ohai "The following existing directories will have their owner set to #{Tty.underline}#{ENV["USER"]}#{Tty.reset}:"
+  ohai "The following existing directories will have their owner set to #{Tty.underline}#{user}#{Tty.reset}:"
   puts(*chowns)
 end
 unless chgrps.empty?
@@ -358,25 +362,25 @@ if File.directory? HOMEBREW_PREFIX
   sudo "/bin/chmod", "u+rwx", *chmods unless chmods.empty?
   sudo "/bin/chmod", "g+rwx", *group_chmods unless group_chmods.empty?
   sudo "/bin/chmod", "755", *user_chmods unless user_chmods.empty?
-  sudo "/bin/chown", ENV["USER"], *chowns unless chowns.empty?
+  sudo "/bin/chown", user, *chowns unless chowns.empty?
   sudo "/bin/chgrp", group, *chgrps unless chgrps.empty?
 else
   sudo "/bin/mkdir", "-p", HOMEBREW_PREFIX
-  sudo "/bin/chown", "#{ENV["USER"]}:#{group}", HOMEBREW_PREFIX
+  sudo "/bin/chown", "#{user}:#{group}", HOMEBREW_PREFIX
 end
 
 unless mkdirs.empty?
   sudo "/bin/mkdir", "-p", *mkdirs
   sudo "/bin/chmod", "g+rwx", *mkdirs
   sudo "/bin/chmod", "755", *zsh_dirs
-  sudo "/bin/chown", ENV["USER"], *mkdirs
+  sudo "/bin/chown", user, *mkdirs
   sudo "/bin/chgrp", group, *mkdirs
 end
 
 [HOMEBREW_CACHE, HOMEBREW_OLD_CACHE].compact.each do |cache|
   sudo "/bin/mkdir", "-p", cache unless File.directory? cache
   sudo "/bin/chmod", "g+rwx", cache if chmod? cache
-  sudo "/bin/chown", ENV["USER"], cache if chown? cache
+  sudo "/bin/chown", user, cache if chown? cache
   sudo "/bin/chgrp", group, cache if chgrp? cache
 end
 

--- a/install-ruby
+++ b/install-ruby
@@ -10,6 +10,8 @@ case $(uname -m) in
   *) echo "Error: Your CPU $(uname -m) is not supported." >&2; exit 1 ;;
 esac
 
+USER=${USER:-`id -un`}
+
 if test -w /home/linuxbrew || /usr/bin/sudo -p "[sudo] Enter password for $USER to install Ruby: " mkdir -p /home/linuxbrew; then
 	prefix=/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor
 	test -w /home/linuxbrew || sudo chown $USER: /home/linuxbrew


### PR DESCRIPTION
The `USER` environment variable is not guaranteed to be present, eg when running
in a Docker container, so gracefully fall back to using `id`.

Fixes #48.