### PR TITLE
Handle existing Ruby below required version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,20 +2,27 @@ language: ruby
 os: linux
 dist: trusty
 sudo: required
-rvm: 2.3.7
 
-before_script:
-  - gem install rubocop
-
-script:
-  - rubocop
-  - ./install --force-curl
-  - ./uninstall -f || true
-  - sudo rm -rf /home/linuxbrew/.linuxbrew
-  - ./install.sh
-  - /home/linuxbrew/.linuxbrew/bin/brew install ack
-  - ./uninstall -f || true
-
+jobs:
+  include:
+    - rvm: 2.2.0
+      gemfile: Gemfile.ruby-2.2.0
+      script:
+        - bundle exec rubocop
+        - ./install.sh
+        - /home/linuxbrew/.linuxbrew/bin/brew install ack
+        - export PATH=/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/current/bin:$PATH
+        - ./uninstall -f || true
+    - rvm: 2.3.7
+      gemfile: Gemfile
+      script:
+        - bundle exec rubocop
+        - ./install --force-curl
+        - ./uninstall -f || true
+        - sudo rm -rf /home/linuxbrew/.linuxbrew
+        - ./install.sh
+        - /home/linuxbrew/.linuxbrew/bin/brew install ack
+        - ./uninstall -f || true
 branches:
   only:
     - master

--- a/Gemfile.ruby-2.2.0
+++ b/Gemfile.ruby-2.2.0
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+group :test do
+  gem "rubocop", "0.64.0"
+end

--- a/Gemfile.ruby-2.2.0.lock
+++ b/Gemfile.ruby-2.2.0.lock
@@ -1,0 +1,29 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.0)
+    jaro_winkler (1.5.3)
+    parallel (1.17.0)
+    parser (2.6.3.0)
+      ast (~> 2.4.0)
+    powerpack (0.1.2)
+    rainbow (3.0.0)
+    rubocop (0.64.0)
+      jaro_winkler (~> 1.5.1)
+      parallel (~> 1.10)
+      parser (>= 2.5, != 2.5.1.1)
+      powerpack (~> 0.1)
+      rainbow (>= 2.2.2, < 4.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.4.0)
+    ruby-progressbar (1.10.1)
+    unicode-display_width (1.4.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  rubocop (= 0.64.0)
+
+BUNDLED WITH
+   1.17.3

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,16 @@
 #!/bin/sh
+
 set -e
 umask 022
-if test -n "$HOMEBREW_FORCE_VENDOR_RUBY" || ! command -v ruby >/dev/null; then
-	eval "`curl -fsSL https://raw.githubusercontent.com/Linuxbrew/install/master/install-ruby`"
+
+# The main Homebrew installer requires at least Ruby 2.3, so this script will
+# install a vendor Ruby if any of the following are true:
+# 1. HOMEBREW_FORCE_VENDOR_RUBY is provided
+# 2. Ruby is not present at all
+# 3. Ruby is present but too old
+if test -n "$HOMEBREW_FORCE_VENDOR_RUBY" || \
+   ! command -v ruby >/dev/null || \
+   (command -v ruby >/dev/null && ruby -e 'exit RUBY_VERSION.split(".").first(2).join(".").to_f < 2.3'); then
+    eval "`curl -fsSL https://raw.githubusercontent.com/Linuxbrew/install/master/install-ruby`"
 fi
 exec ruby -e "`curl -fsSL https://raw.githubusercontent.com/Linuxbrew/install/master/install`" "$@"


### PR DESCRIPTION
Add a check to the install wrapper script to ensure that if Ruby is available,
it's at least the required version.

Fixes #65.