### PR TITLE
Fix chgrp to use var instead of hardcoded value

### DIFF
--- a/install
+++ b/install
@@ -349,7 +349,7 @@ end
 sudo "/bin/mkdir", "-p", HOMEBREW_CACHE unless File.directory? HOMEBREW_CACHE
 sudo "/bin/chmod", "g+rwx", HOMEBREW_CACHE if chmod? HOMEBREW_CACHE
 sudo CHOWN, ENV["USER"], HOMEBREW_CACHE if chown? HOMEBREW_CACHE
-sudo CHGRP, "admin", HOMEBREW_CACHE if chgrp? HOMEBREW_CACHE
+sudo CHGRP, group, HOMEBREW_CACHE if chgrp? HOMEBREW_CACHE
 system "/usr/bin/touch", "#{HOMEBREW_CACHE}/.cleaned" if File.directory? HOMEBREW_CACHE
 
 if should_install_command_line_tools?


### PR DESCRIPTION
This was modified from the previous behavior here https://github.com/Linuxbrew/install/commit/2f1ab30398437ff7a46242c3e55e47e82f9acbb4#diff-19ad89bc3e3c9d7ef68b89523eff1987R361

The change caused installation to fail for us on our CI builders, as we don't have an "admin" group on the machines we're installing brew on.